### PR TITLE
Update baseline name to CAF.Strict

### DIFF
--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -146,13 +146,16 @@ task VersionModule ModuleDependencies, {
         if ($_.Name -eq 'PSRule' -and $Configuration -eq 'Release') {
             @{ ModuleName = 'PSRule'; ModuleVersion = '0.13.0' }
         }
+        elseif ($_.Name -eq 'PSRule.Rules.Azure' -and $Configuration -eq 'Release') {
+            @{ ModuleName = 'PSRule.Rules.Azure'; ModuleVersion = '0.7.0' }
+        }
         else {
             @{ ModuleName = $_.Name; ModuleVersion = $_.Version }
         }
     };
     Update-ModuleManifest -Path $manifestPath -RequiredModules $requiredModules;
     $manifestContent = Get-Content -Path $manifestPath -Raw;
-    $manifestContent = $manifestContent -replace 'PSRule = ''System.Collections.Hashtable''', 'PSRule = @{ Baseline = ''CAF.Default'' }';
+    $manifestContent = $manifestContent -replace 'PSRule = ''System.Collections.Hashtable''', 'PSRule = @{ Baseline = ''CAF.Strict'' }';
     $manifestContent | Set-Content -Path $manifestPath;
 }
 

--- a/src/PSRule.Rules.CAF/PSRule.Rules.CAF.psd1
+++ b/src/PSRule.Rules.CAF/PSRule.Rules.CAF.psd1
@@ -96,7 +96,7 @@ AliasesToExport = @()
 PrivateData = @{
     PSData = @{
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = @('Rule', 'PSRule', 'Azure', 'CAF', 'Cloud')
+        Tags = @('PSRule', 'PSRule-rules', 'Rule', 'Azure', 'CAF', 'Cloud')
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/Microsoft/PSRule.Rules.CAF/blob/master/LICENSE'
@@ -111,7 +111,7 @@ PrivateData = @{
         ReleaseNotes = 'https://github.com/Microsoft/PSRule.Rules.CAF/blob/master/CHANGELOG.md'
     } # End of PSData hashtable
     PSRule = @{
-        Baseline = 'CAF.Default'
+        Baseline = 'CAF.Strict'
     }
 } # End of PrivateData hashtable
 

--- a/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
@@ -3,7 +3,7 @@
 # Synopsis: The default baseline for Azure Cloud Adoption Framework
 kind: Baseline
 metadata:
-  name: CAF.Default
+  name: CAF.Strict
 spec:
   binding:
     targetType:


### PR DESCRIPTION
## PR Summary

- Rename baseline from `CAF.Default` to `CAF.Strict`.
- Updated CI pipeline to update `PSRule.Rules.Azure` dependency.
- Updated to use PSRule v0.13.0.
- Added `PSRule-rules` module tag.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
