### PR TITLE
Rule updates and fixes #27 #28 #29 #30 #31 #32

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,8 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "test",
+            "label": "Test",
+            "detail": "Build and run unit tests.",
             "type": "shell",
             "command": "Invoke-Build Test -AssertStyle Client",
             "group": {
@@ -69,6 +70,13 @@
             "label": "scaffold-docs",
             "type": "shell",
             "command": "Invoke-Build ScaffoldHelp",
+            "problemMatcher": []
+        },
+        {
+            "label": "Rule docs",
+            "detail": "Generate rule table of contents.",
+            "type": "shell",
+            "command": "Invoke-Build BuildRuleDocs",
             "problemMatcher": []
         }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@
 
 - General improvements:
   - Updated rule content to align with Microsoft Azure Well-Architected Framework pillars. [#23](https://github.com/microsoft/PSRule.Rules.CAF/issues/23)
+  - Updated naming rules to check for recommended naming prefixes. [#29](https://github.com/microsoft/PSRule.Rules.CAF/issues/29)
+    - Checks to determine if a resource name is valid are available in `PSRule.Rules.Azure`.
 - Engineering:
   - Updated to PSRule v0.20.0. [#24](https://github.com/microsoft/PSRule.Rules.CAF/issues/24)
+- Bug fixes:
+  - Fixed Storage Account `st` prefix. [#28](https://github.com/microsoft/PSRule.Rules.CAF/issues/28)
+  - Fixed Virtual Network Gateway `vgw-` prefix. [#30](https://github.com/microsoft/PSRule.Rules.CAF/issues/30)
+  - Fixed Virtual Machine `vm` prefix. [#31](https://github.com/microsoft/PSRule.Rules.CAF/issues/31)
+  - Fixed Load Balancer `lbe-` and `lbi-` prefixes. [#32](https://github.com/microsoft/PSRule.Rules.CAF/issues/32)
+  - Fixed exclude `AzureFirewallSubnet` from `CAF.Name.Subnet`. [#27](https://github.com/microsoft/PSRule.Rules.CAF/issues/27)
 
 ## v0.1.0-B2008005 (pre-release)
 

--- a/docs/rules/en/CAF.Name.Connection.md
+++ b/docs/rules/en/CAF.Name.Connection.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.Connection.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Virtual network gateway connection names should use a standard prefix and meet naming requirements.
+Virtual network gateway connection names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.LoadBalancer.md
+++ b/docs/rules/en/CAF.Name.LoadBalancer.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.LoadBalancer.md
 ---
 
@@ -8,14 +8,15 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Load balancer names should use a standard prefix and meet naming requirements.
+Load balancer names should use a standard prefix.
 
 ## DESCRIPTION
 
 An effective naming convention allows operators to quickly identify resource type, associated workload,
 deployment environment and Azure region.
 
-For load balancers, the Cloud Adoption Framework recommends using the `lb-` prefix.
+For load balancers, the Cloud Adoption Framework recommends using the `lbi-`, and `lbe-` prefix.
+Use of different prefixes depends on the intended usage of the load balancer.
 
 Requirements for load balancers names:
 

--- a/docs/rules/en/CAF.Name.NSG.md
+++ b/docs/rules/en/CAF.Name.NSG.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.NSG.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Network security group (NSG) names should use a standard prefix and meet naming requirements.
+Network security group (NSG) names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.PublicIP.md
+++ b/docs/rules/en/CAF.Name.PublicIP.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.PublicIP.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Public IP address names should use a standard prefix and meet naming requirements.
+Public IP address names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.RG.md
+++ b/docs/rules/en/CAF.Name.RG.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.RG.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Resource group names should use a standard prefix and meet naming requirements.
+Resource group names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.Route.md
+++ b/docs/rules/en/CAF.Name.Route.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.Route.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Route table names should use a standard prefix and meet naming requirements.
+Route table names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.Storage.md
+++ b/docs/rules/en/CAF.Name.Storage.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.Storage.md
 ---
 
@@ -8,14 +8,14 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Storage account names should use a standard prefix and meet naming requirements.
+Storage account names should use a standard prefix.
 
 ## DESCRIPTION
 
 An effective naming convention allows operators to quickly identify resource type, associated workload,
 deployment environment and Azure region.
 
-For storage accounts, the Cloud Adoption Framework recommends using the `stor`, `stvm` and `dls` prefix.
+For storage accounts, the Cloud Adoption Framework recommends using the `st`, `stvm`, and `dls` prefix.
 Use of different prefixes depends on the intended usage of the storage account.
 
 Requirements for storage account names:

--- a/docs/rules/en/CAF.Name.Subnet.md
+++ b/docs/rules/en/CAF.Name.Subnet.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.Subnet.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Subnet names should use a standard prefix and meet naming requirements.
+Subnet names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.VM.md
+++ b/docs/rules/en/CAF.Name.VM.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.VM.md
 ---
 
@@ -8,14 +8,14 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Virtual machine names should use a standard prefix and meet naming requirements.
+Virtual machine names should use a standard prefix.
 
 ## DESCRIPTION
 
 An effective naming convention allows operators to quickly identify resource type, associated workload,
 deployment environment and Azure region.
 
-For VMs, the Cloud Adoption Framework recommends using the `vm-` prefix.
+For VMs, the Cloud Adoption Framework recommends using the `vm` prefix.
 
 Requirements for VM names:
 

--- a/docs/rules/en/CAF.Name.VNET.md
+++ b/docs/rules/en/CAF.Name.VNET.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.VNET.md
 ---
 
@@ -8,7 +8,7 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Virtual network names should use a standard prefix and meet naming requirements.
+Virtual network names should use a standard prefix.
 
 ## DESCRIPTION
 

--- a/docs/rules/en/CAF.Name.VNG.md
+++ b/docs/rules/en/CAF.Name.VNG.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Resource naming
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.VNG.md
 ---
 
@@ -8,14 +8,14 @@ online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rul
 
 ## SYNOPSIS
 
-Virtual network gateway names should use a standard prefix and meet naming requirements.
+Virtual network gateway names should use a standard prefix.
 
 ## DESCRIPTION
 
 An effective naming convention allows operators to quickly identify resource type, associated workload,
 deployment environment and Azure region.
 
-For virtual network gateways, the Cloud Adoption Framework recommends using the `vnet-gw-` prefix.
+For virtual network gateways, the Cloud Adoption Framework recommends using the `vgw-` prefix.
 
 Requirements for virtual network gateway names:
 

--- a/docs/rules/en/CAF.Tag.Environment.md
+++ b/docs/rules/en/CAF.Tag.Environment.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Metadata tagging
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Tag.Environment.md
 ---
 

--- a/docs/rules/en/CAF.Tag.Required.md
+++ b/docs/rules/en/CAF.Tag.Required.md
@@ -1,6 +1,6 @@
 ---
 pillar: Operational Excellence
-category: Tagging and resource naming
+category: Metadata tagging
 online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Tag.Required.md
 ---
 

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -4,25 +4,25 @@
 
 The following rules are included within `PSRule.Rules.CAF`.
 
-### Naming
-
-Name | Synopsis
----- | --------
-[CAF.Name.Connection](CAF.Name.Connection.md) | Virtual network gateway connection names should use a standard prefix and meet naming requirements.
-[CAF.Name.LoadBalancer](CAF.Name.LoadBalancer.md) | Load balancer names should use a standard prefix and meet naming requirements.
-[CAF.Name.NSG](CAF.Name.NSG.md) | Network security group (NSG) names should use a standard prefix and meet naming requirements.
-[CAF.Name.PublicIP](CAF.Name.PublicIP.md) | Public IP address names should use a standard prefix and meet naming requirements.
-[CAF.Name.RG](CAF.Name.RG.md) | Resource group names should use a standard prefix and meet naming requirements.
-[CAF.Name.Route](CAF.Name.Route.md) | Route table names should use a standard prefix and meet naming requirements.
-[CAF.Name.Storage](CAF.Name.Storage.md) | Storage account names should use a standard prefix and meet naming requirements.
-[CAF.Name.Subnet](CAF.Name.Subnet.md) | Subnet names should use a standard prefix and meet naming requirements.
-[CAF.Name.VM](CAF.Name.VM.md) | Virtual machine names should use a standard prefix and meet naming requirements.
-[CAF.Name.VNET](CAF.Name.VNET.md) | Virtual network names should use a standard prefix and meet naming requirements.
-[CAF.Name.VNG](CAF.Name.VNG.md) | Virtual network gateway names should use a standard prefix and meet naming requirements.
-
-### Tagging
+### Metadata tagging
 
 Name | Synopsis
 ---- | --------
 [CAF.Tag.Environment](CAF.Tag.Environment.md) | Tag resources and resource groups with a valid environment.
 [CAF.Tag.Required](CAF.Tag.Required.md) | Tag resources and resource groups with mandatory tags.
+
+### Resource naming
+
+Name | Synopsis
+---- | --------
+[CAF.Name.Connection](CAF.Name.Connection.md) | Virtual network gateway connection names should use a standard prefix.
+[CAF.Name.LoadBalancer](CAF.Name.LoadBalancer.md) | Load balancer names should use a standard prefix.
+[CAF.Name.NSG](CAF.Name.NSG.md) | Network security group (NSG) names should use a standard prefix.
+[CAF.Name.PublicIP](CAF.Name.PublicIP.md) | Public IP address names should use a standard prefix.
+[CAF.Name.RG](CAF.Name.RG.md) | Resource group names should use a standard prefix.
+[CAF.Name.Route](CAF.Name.Route.md) | Route table names should use a standard prefix.
+[CAF.Name.Storage](CAF.Name.Storage.md) | Storage account names should use a standard prefix.
+[CAF.Name.Subnet](CAF.Name.Subnet.md) | Subnet names should use a standard prefix.
+[CAF.Name.VM](CAF.Name.VM.md) | Virtual machine names should use a standard prefix.
+[CAF.Name.VNET](CAF.Name.VNET.md) | Virtual network names should use a standard prefix.
+[CAF.Name.VNG](CAF.Name.VNG.md) | Virtual network gateway names should use a standard prefix.

--- a/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
@@ -5,61 +5,80 @@ kind: Baseline
 metadata:
   name: CAF.Strict
 spec:
-  binding:
-    targetType:
-    - 'ResourceType'
-    - 'Type'
-    targetName:
-    - 'ResourceName'
-    - 'Name'
-    field:
-      resourceId: [ 'ResourceId' ]
-      subscriptionId: [ 'SubscriptionId' ]
-      resourceGroupName: [ 'ResourceGroupName' ]
 
   configuration:
-    # Name prefixes
+    # General
     CAF_ResourceGroupPrefix: [ 'rg-' ]
+    CAF_PolicyDefinitionPrefix: [ 'policy-' ]
+    CAF_APIManagementPrefix: [ 'apim-' ]
+
+    # Networking
     CAF_VirtualNetworkPrefix: [ 'vnet-' ]
-    CAF_VirtualNetworkGatewayPrefix: [ 'vnet-gw-' ]
-    CAF_GatewayConnectionPrefix: [ 'cn-' ]
     CAF_SubnetPrefix: [ 'snet-' ]
-    CAF_NetworkSecurityGroupPrefix: [ 'nsg-' ]
-    CAF_RouteTablePrefix: [ 'route-' ]
-    CAF_VirtualMachinePrefix: [ 'vm-' ]
-    CAF_StoragePrefix: [ 'stor', 'stvm', 'dls' ]
-    CAF_PublicIPPrefix: [ 'pip-' ]
-    CAF_LoadBalancerPrefix: [ 'lb-' ]
     CAF_NetworkInterfacePrefix: [ 'nic-' ]
-    CAF_KeyVaultPrefix: [ 'kv-' ]
+    CAF_PublicIPPrefix: [ 'pip-' ]
+    CAF_LoadBalancerPrefix: [ 'lbi-', 'lbe-' ]
+    CAF_NetworkSecurityGroupPrefix: [ 'nsg-' ]
+    CAF_ApplicationSecurityGroupPrefix: [ 'asg-' ]
+    CAF_LocalNetworkGatewayPrefix: [ 'lgw-' ]
+    CAF_VirtualNetworkGatewayPrefix: [ 'vgw-' ]
+    CAF_GatewayConnectionPrefix: [ 'cn-' ]
+    CAF_ApplicationGatewayPrefix: [ 'agw-' ]
+    CAF_RouteTablePrefix: [ 'route-' ]
+    CAF_TrafficManagerProfilePrefix: [ 'traf-' ]
+
+    # Compute and Web
+    CAF_VirtualMachinePrefix: [ 'vm' ]
+    CAF_VirtualMachineScaleSetPrefix: [ 'vmss-' ]
+    CAF_AvailabilitySetPrefix: [ 'avail-' ]
+    CAF_ContainerInstancePrefix: [ 'aci-' ]
     CAF_AKSClusterPrefix: [ 'aks-' ]
-    CAF_ServiceBusPrefix: [ 'sb-' ]
-    CAF_ServiceBusQueuePrefix: [ 'sbq-' ]
-    CAF_AppServiceAppPrefix: [ 'azapp-' ]
-    CAF_FunctionAppPrefix: [ 'azfun-' ]
-    CAF_CloudServicePrefix: [ 'azcs-' ]
+    CAF_AppServicePlanPrefix: [ 'plan-' ]
+    CAF_WebAppPrefix: [ 'app-' ]
+    CAF_FunctionAppPrefix: [ 'func-' ]
+    CAF_CloudServicePrefix: [ 'cld-' ]
+    CAF_NotificationHubPrefix: [ 'ntf-' ]
+    CAF_NotificationHubNamespacePrefix: [ 'ntfns-' ]
+
+    # Databases
+    CAF_SQLDatabaseServerPrefix: [ 'sql-' ]
     CAF_SQLDatabasePrefix: [ 'sqldb-' ]
-    CAF_CosmosDbPrefix: [ 'cosdb-' ]
+    CAF_CosmosDbPrefix: [ 'cosmos-' ]
     CAF_RedisCachePrefix: [ 'redis-' ]
     CAF_MySQLDatabasePrefix: [ 'mysql-' ]
+    CAF_PostgreSQLDatabasePrefix: [ 'psql-' ]
     CAF_SQLDataWarehousePrefix: [ 'sqldw-' ]
+    CAF_SynapseAnalyticsPrefix: [ 'syn-' ]
     CAF_SQLStretchDbPrefix: [ 'sqlstrdb-' ]
+
+    # Storage
+    CAF_StoragePrefix: [ 'st', 'stvm', 'dls' ]
     CAF_StorSimplePrefix: [ 'ssimp' ]
+
+    # AI and Machine Learning
     CAF_SearchPrefix: [ 'srch-' ]
-    CAF_CognitiveServicesPrefix: [ 'cs-' ]
-    CAF_MachineLearningWorkspacePrefix: [ 'aml-' ]
-    CAF_DataLakeAnalyticsPrefix: [ 'dla' ]
-    CAF_HDInsightsSparkPrefix: [ 'hdis-' ]
-    CAF_HDInsightsHadoopPrefix: [ 'hdihd-' ]
-    CAF_HDInsightsRServerPrefix: [ 'hdir-' ]
-    CAF_HDInsightsHBasePrefix: [ 'hdihb-' ]
-    CAF_PowerBIEmbeddedPrefix: [ 'pbiemb' ]
+    CAF_CognitiveServicesPrefix: [ 'cog-' ]
+    CAF_MachineLearningWorkspacePrefix: [ 'mlw-' ]
+
+    # Analytics and IoT
     CAF_StreamAnalyticsPrefix: [ 'asa-' ]
-    CAF_DataFactoryPrefix: [ 'df-' ]
+    CAF_DataFactoryPrefix: [ 'adf-' ]
+    CAF_DataLakeStorePrefix: [ 'dla' ]
     CAF_EventHubsPrefix: [ 'evh-' ]
-    CAF_IoTHubPrefix: [ 'aih-' ]
-    CAF_NotificationHubPrefix: [ 'anh-' ]
-    CAF_NotificationHubNSPrefix: [ 'anhns-' ]
+    CAF_HDInsightsHadoopPrefix: [ 'hadoop-' ]
+    CAF_HDInsightsHBasePrefix: [ 'hbase-' ]
+    CAF_HDInsightsSparkPrefix: [ 'spark-' ]
+    CAF_IoTHubPrefix: [ 'iot-' ]
+    CAF_PowerBIEmbeddedPrefix: [ 'pbi-' ]
+
+    # Integration
+    CAF_LogicAppsPrefix: [ 'logic-' ]
+    CAF_ServiceBusPrefix: [ 'sb-' ]
+    CAF_ServiceBusQueuePrefix: [ 'sbq-' ]
+    CAF_ServiceBusTopicPrefix: [ 'sbt-' ]
+
+    # Management and governance
+    CAF_KeyVaultPrefix: [ 'kv-' ]
 
     # Required tags
     CAF_ResourceMandatoryTags: [ ]

--- a/src/PSRule.Rules.CAF/rules/CAF.Name.Rule.ps1
+++ b/src/PSRule.Rules.CAF/rules/CAF.Name.Rule.ps1
@@ -6,139 +6,71 @@
 # https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
 # https://docs.microsoft.com/en-us/azure/architecture/best-practices/resource-naming
 
-# Synopsis: Use standard resource groups names
+# Synopsis: Use standard resource groups names.
 Rule 'CAF.Name.RG' -Type 'Microsoft.Resources/resourceGroups' -If { !(CAF_IsManagedRG) } {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_ResourceGroupPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 90)
-    Match 'Name' '^[-\w\._\(\)]*[-\w_\(\)]$'
 }
 
-# Synopsis: Use standard virtual networks names
+# Synopsis: Use standard virtual networks names.
 Rule 'CAF.Name.VNET' -Type 'Microsoft.Network/virtualNetworks' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_VirtualNetworkPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 2)
-    $Assert.LessOrEqual($TargetObject, 'Name', 64)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
 
-# Synopsis: Use standard subnets names
+# Synopsis: Use standard subnets names.
 Rule 'CAF.Name.Subnet' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.Network/virtualNetworks/subnets' {
+    $subnets = @($TargetObject);
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
-        foreach ($subnet in $TargetObject.Properties.subnets) {
-            if ($subnet.name -eq 'GatewaySubnet') {
-                $Assert.Pass();
-            }
-            else {
-                $Assert.StartsWith($subnet, 'Name', $Configuration.CAF_SubnetPrefix)
-
-                # Name requirements
-                $Assert.GreaterOrEqual($subnet, 'Name', 2)
-                $Assert.LessOrEqual($subnet, 'Name', 80)
-                $subnet | Match 'Name' '^[\w][-\w_\.]*[\w_]$'
-            }
-        }
+        $subnets = @($TargetObject.Properties.subnets);
     }
-    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets') {
-        if ($PSRule.TargetName -eq 'GatewaySubnet') {
+    if ($subnets.Length -eq 0) {
+        $Assert.Pass();
+    }
+    foreach ($subnet in $subnets) {
+        if ($subnet.Name -in 'GatewaySubnet', 'AzureFirewallSubnet') {
             $Assert.Pass();
         }
         else {
-            $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_SubnetPrefix)
-
-            # Name requirements
-            $Assert.GreaterOrEqual($subnet, 'Name', 2)
-            $Assert.LessOrEqual($subnet, 'Name', 80)
-            $subnet | Match 'Name' '^[\w][-\w_\.]*[\w_]$'
+            $Assert.StartsWith($subnet, 'Name', $Configuration.CAF_SubnetPrefix)
         }
     }
 }
 
-# Synopsis: Use standard virtual network gateway names
+# Synopsis: Use standard virtual network gateway names.
 Rule 'CAF.Name.VNG' -Type 'Microsoft.Network/virtualNetworkGateways' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_VirtualNetworkGatewayPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 80)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
 
-# Synopsis: Use standard virtual networks gateway connection names
+# Synopsis: Use standard virtual networks gateway connection names.
 Rule 'CAF.Name.Connection' -Type 'Microsoft.Network/connections' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_GatewayConnectionPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 80)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
 
-# Synopsis: Use standard network security group names
+# Synopsis: Use standard network security group names.
 Rule 'CAF.Name.NSG' -Type 'Microsoft.Network/networkSecurityGroups' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_NetworkSecurityGroupPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 80)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
 
-# Synopsis: Use standard route table names
+# Synopsis: Use standard route table names.
 Rule 'CAF.Name.Route' -Type 'Microsoft.Network/routeTables' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_RouteTablePrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 80)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
 
-# Synopsis: Use standard virtual machines names
+# Synopsis: Use standard virtual machines names.
 Rule 'CAF.Name.VM' -Type 'Microsoft.Compute/virtualMachines' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_VirtualMachinePrefix)
 }
 
-# Synopsis: Use standard storage accounts names
+# Synopsis: Use standard storage accounts names.
 Rule 'CAF.Name.Storage' -Type 'Microsoft.Storage/storageAccounts' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_StoragePrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 3)
-    $Assert.LessOrEqual($TargetObject, 'Name', 24)
-    Match 'Name' '^[a-z0-9]+$' -CaseSensitive
 }
 
-# Synopsis: Use standard public IP address names
+# Synopsis: Use standard public IP address names.
 Rule 'CAF.Name.PublicIP' -Type 'Microsoft.Network/publicIPAddresses' {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_PublicIPPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 80)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
 
-# Synopsis: Use standard load balancer names
+# Synopsis: Use standard load balancer names.
 Rule 'CAF.Name.LoadBalancer' -Type 'Microsoft.Network/loadBalancers' -If { !(CAF_IsManagedLB) } {
     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_LoadBalancerPrefix)
-
-    # Name requirements
-    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-    $Assert.LessOrEqual($TargetObject, 'Name', 80)
-    Match 'Name' '^[\w][-\w_\.]*[\w_]$'
 }
-
-# Rule 'CAF.Name.ACR' -Type 'Microsoft.ContainerRegistry/registries' {
-#     $Assert.StartsWith($TargetObject, 'Name', $Configuration.CAF_ACRPrefix)
-
-#     # Name requirements
-#     $Assert.GreaterOrEqual($TargetObject, 'Name', 5)
-#     $Assert.LessOrEqual($TargetObject, 'Name', 50)
-
-#     # Match 'Name' '^[a-zA-Z0-9]*$'
-# }

--- a/src/PSRule.Rules.CAF/rules/CAF.Tag.Rule.ps1
+++ b/src/PSRule.Rules.CAF/rules/CAF.Tag.Rule.ps1
@@ -26,5 +26,5 @@ Rule 'CAF.Tag.Required' -If { (CAF_SupportsTags) } {
 
 # Synopsis: Use standard environment tag values
 Rule 'CAF.Tag.Environment' -If { (CAF_SupportsTags) -and (Exists "Tags.$($Configuration.CAF_EnvironmentTag)") } {
-    Within "Tags.$($Configuration.CAF_EnvironmentTag)" $Configuration.CAF_Environments
+    $Assert.In($TargetObject, "Tags.$($Configuration.CAF_EnvironmentTag)", $Configuration.CAF_Environments)
 }

--- a/src/PSRule.Rules.CAF/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Config.Rule.yaml
@@ -1,0 +1,18 @@
+
+---
+# Synopsis: 
+kind: ModuleConfig
+metadata:
+  name: PSRule.Rules.CAF
+spec:
+  binding:
+    targetType:
+    - 'ResourceType'
+    - 'Type'
+    targetName:
+    - 'ResourceName'
+    - 'Name'
+    field:
+      resourceId: [ 'ResourceId' ]
+      subscriptionId: [ 'SubscriptionId' ]
+      resourceGroupName: [ 'ResourceGroupName' ]

--- a/tests/PSRule.Rules.CAF.Tests/CAF.Name.Tests.ps1
+++ b/tests/PSRule.Rules.CAF.Tests/CAF.Name.Tests.ps1
@@ -56,14 +56,14 @@ Describe 'CAF.Name' -Tag 'name' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'vnetB', 'vnet-C-';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'vnetB';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-D';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-D', 'vnet-C';
         }
 
         It 'CAF.Name.Subnet' {
@@ -79,7 +79,7 @@ Describe 'CAF.Name' -Tag 'name' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-C-';
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-C';
         }
 
         It 'CAF.Name.VNG' {
@@ -95,7 +95,7 @@ Describe 'CAF.Name' -Tag 'name' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-gw-B';
+            $ruleResult.TargetName | Should -Be 'vgw-B';
         }
 
         It 'CAF.Name.Connection' {
@@ -153,7 +153,7 @@ Describe 'CAF.Name' -Tag 'name' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vmB';
+            $ruleResult.TargetName | Should -Be 'bvm';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -207,7 +207,7 @@ Describe 'CAF.Name' -Tag 'name' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'lb-A';
+            $ruleResult.TargetName | Should -Be 'lbe-A';
         }
     }
 }

--- a/tests/PSRule.Rules.CAF.Tests/Resources.Network.json
+++ b/tests/PSRule.Rules.CAF.Tests/Resources.Network.json
@@ -294,11 +294,11 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C-",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C-",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C",
         "Location": "region",
-        "ResourceName": "vnet-C-",
-        "Name": "vnet-C-",
+        "ResourceName": "vnet-C",
+        "Name": "vnet-C",
         "Properties": {
             "addressSpace": {
                 "addressPrefixes": [
@@ -363,7 +363,7 @@
                     "type": "Microsoft.Network/virtualNetworks/subnets"
                 },
                 {
-                    "name": "snet-D",
+                    "name": "AzureFirewallSubnet",
                     "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/subnets/subnet-D",
                     "properties": {
                         "addressPrefix": "10.3.0.80/28",
@@ -2004,32 +2004,32 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A",
         "Location": "region",
         "ManagedBy": null,
-        "ResourceName": "lb-A",
-        "Name": "lb-A",
+        "ResourceName": "lbe-A",
+        "Name": "lbe-A",
         "Properties": {
             "provisioningState": "Succeeded",
             "resourceGuid": "00000000-0000-0000-0000-000000000000",
             "frontendIPConfigurations": [
                 {
                     "name": "frontend-A",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/frontendIPConfigurations/frontend-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/frontendIPConfigurations/frontend-A",
                     "type": "Microsoft.Network/loadBalancers/frontendIPConfigurations",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "privateIPAllocationMethod": "Dynamic",
                         "publicIPAddress": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/lb-A-ip-A"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/lbe-A-ip-A"
                         },
                         "loadBalancingRules": [
                             {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-80"
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-80"
                             },
                             {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-443"
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-443"
                             }
                         ],
                         "privateIPAddressVersion": "IPv4"
@@ -2038,8 +2038,8 @@
             ],
             "backendAddressPools": [
                 {
-                    "name": "lb-A",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/backendAddressPools/lb-A",
+                    "name": "lbe-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/backendAddressPools/lbe-A",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "backendIPConfigurations": [
@@ -2055,10 +2055,10 @@
                         ],
                         "loadBalancingRules": [
                             {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-80"
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-80"
                             },
                             {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-443"
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-443"
                             }
                         ]
                     },
@@ -2068,12 +2068,12 @@
             "loadBalancingRules": [
                 {
                     "name": "rule-TCP-80",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-80",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-80",
                     "type": "Microsoft.Network/loadBalancers/loadBalancingRules",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "frontendIPConfiguration": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/frontendIPConfigurations/frontend-A"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/frontendIPConfigurations/frontend-A"
                         },
                         "frontendPort": 80,
                         "backendPort": 80,
@@ -2085,21 +2085,21 @@
                         "allowBackendPortConflict": false,
                         "loadDistribution": "Default",
                         "backendAddressPool": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/backendAddressPools/lb-A"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/backendAddressPools/lbe-A"
                         },
                         "probe": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/probes/probe-TCP-80"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/probes/probe-TCP-80"
                         }
                     }
                 },
                 {
                     "name": "rule-TCP-443",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-443",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-443",
                     "type": "Microsoft.Network/loadBalancers/loadBalancingRules",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "frontendIPConfiguration": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/frontendIPConfigurations/frontend-A"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/frontendIPConfigurations/frontend-A"
                         },
                         "frontendPort": 443,
                         "backendPort": 443,
@@ -2111,10 +2111,10 @@
                         "allowBackendPortConflict": false,
                         "loadDistribution": "Default",
                         "backendAddressPool": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/backendAddressPools/lb-A"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/backendAddressPools/lbe-A"
                         },
                         "probe": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/probes/probe-TCP-443"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/probes/probe-TCP-443"
                         }
                     }
                 }
@@ -2122,7 +2122,7 @@
             "probes": [
                 {
                     "name": "probe-TCP-80",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/probes/probe-TCP-80",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/probes/probe-TCP-80",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "protocol": "Http",
@@ -2132,7 +2132,7 @@
                         "numberOfProbes": 2,
                         "loadBalancingRules": [
                             {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-80"
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-80"
                             }
                         ]
                     },
@@ -2140,7 +2140,7 @@
                 },
                 {
                     "name": "probe-TCP-443",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/probes/probe-TCP-443",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/probes/probe-TCP-443",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "protocol": "Http",
@@ -2150,7 +2150,7 @@
                         "numberOfProbes": 2,
                         "loadBalancingRules": [
                             {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/loadBalancingRules/rule-TCP-443"
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/loadBalancingRules/rule-TCP-443"
                             }
                         ]
                     },
@@ -2432,7 +2432,7 @@
             "idleTimeoutInMinutes": 4,
             "ipTags": [],
             "ipConfiguration": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/frontendIPConfigurations/config-A"
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/frontendIPConfigurations/config-A"
             }
         },
         "ResourceGroupName": "test-rg",
@@ -2466,7 +2466,7 @@
             "idleTimeoutInMinutes": 4,
             "ipTags": [],
             "ipConfiguration": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A/frontendIPConfigurations/config-A"
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lbe-A/frontendIPConfigurations/config-A"
             }
         },
         "ResourceGroupName": "test-rg",

--- a/tests/PSRule.Rules.CAF.Tests/Resources.VM.json
+++ b/tests/PSRule.Rules.CAF.Tests/Resources.VM.json
@@ -124,9 +124,9 @@
         ]
     },
     {
-        "Name": "vmB",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vmB",
-        "ResourceName": "vmB",
+        "Name": "bvm",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/bvm",
+        "ResourceName": "bvm",
         "ResourceType": "Microsoft.Compute/virtualMachines",
         "ResourceGroupName": "test-rg",
         "Location": "region",
@@ -144,19 +144,19 @@
                 },
                 "osDisk": {
                     "osType": "Windows",
-                    "name": "vmB_OsDisk_1_0000000000000000000000000000000",
+                    "name": "bvm_OsDisk_1_0000000000000000000000000000000",
                     "createOption": "FromImage",
                     "caching": "ReadWrite",
                     "managedDisk": {
                         "storageAccountType": "StandardSSD_LRS",
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vmB_OsDisk_1_0000000000000000000000000000000"
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/bvm_OsDisk_1_0000000000000000000000000000000"
                     },
                     "diskSizeGB": 127
                 },
                 "dataDisks": [
                     {
                         "lun": 0,
-                        "name": "vmB_disk2_0000000000000000000000000000000",
+                        "name": "bvm_disk2_0000000000000000000000000000000",
                         "createOption": "Empty",
                         "caching": "ReadOnly",
                         "diskSizeGB": 1023
@@ -164,7 +164,7 @@
                 ]
             },
             "osProfile": {
-                "computerName": "vmB",
+                "computerName": "bvm",
                 "adminUsername": "vm-admin",
                 "windowsConfiguration": {
                     "provisionVMAgent": false,
@@ -176,7 +176,7 @@
             "networkProfile": {
                 "networkInterfaces": [
                     {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vmB-nic"
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/bvm-nic"
                     }
                 ]
             },
@@ -229,7 +229,7 @@
                     "enableIPForwarding": false,
                     "primary": true,
                     "virtualMachine": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vmB"
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/bvm"
                     },
                     "hostedWorkloads": [],
                     "tapConfigurations": []

--- a/tests/PSRule.Rules.CAF.Tests/Resources.VNG.json
+++ b/tests/PSRule.Rules.CAF.Tests/Resources.VNG.json
@@ -54,14 +54,14 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vnet-gw-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vnet-gw-B",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vgw-B",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vgw-B",
         "Identity": null,
         "Kind": null,
         "Location": "region",
         "ManagedBy": null,
-        "ResourceName": "vnet-gw-B",
-        "Name": "vnet-gw-B",
+        "ResourceName": "vgw-B",
+        "Name": "vgw-B",
         "ExtensionResourceName": null,
         "ParentResource": null,
         "Plan": null,
@@ -70,13 +70,13 @@
             "ipConfigurations": [
                 {
                     "name": "default",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vnet-gw-B/ipConfigurations/default",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vgw-B/ipConfigurations/default",
                     "type": "Microsoft.Network/virtualNetworkGateways/ipConfigurations",
                     "properties": {
                         "provisioningState": "Succeeded",
                         "privateIPAllocationMethod": "Dynamic",
                         "publicIPAddress": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/vnet-gw-B-pip"
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/vgw-B-pip"
                         },
                         "subnet": {
                             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-rg/subnets/GatewaySubnet"
@@ -185,7 +185,7 @@
             "provisioningState": "Succeeded",
             "resourceGuid": "00000000-0000-0000-0000-000000000000",
             "virtualNetworkGateway1": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vnet-gw-B"
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vgw-B"
             },
             "localNetworkGateway2": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/localNetworkGateways/lng-A"
@@ -234,7 +234,7 @@
             "provisioningState": "Succeeded",
             "resourceGuid": "00000000-0000-0000-0000-000000000000",
             "virtualNetworkGateway1": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vnet-gw-B"
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworkGateways/vgw-B"
             },
             "localNetworkGateway2": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/localNetworkGateways/lng-A"


### PR DESCRIPTION
## PR Summary

- General improvements:
  - Updated naming rules to check for recommended naming prefixes. #29
    - Checks to determine if a resource name is valid are available in `PSRule.Rules.Azure`.
- Bug fixes:
  - Fixed Storage Account `st` prefix. #28
  - Fixed Virtual Network Gateway `vgw-` prefix. #30
  - Fixed Virtual Machine `vm` prefix. #31
  - Fixed Load Balancer `lbe-` and `lbi-` prefixes. #32
  - Fixed exclude `AzureFirewallSubnet` from `CAF.Name.Subnet`. #27

Fixes #27 
Fixes #28 
Fixes #29 
Fixes #30 
Fixes #31 
Fixes #32 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.CAF/blob/main/CHANGELOG.md) has been updated with change under unreleased section
