### PR TITLE
Pre-release v0.1.0-B2009009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.1.0-B2009009 (pre-release)
+
+What's changed since pre-release v0.1.0-B2008005:
+
 - General improvements:
   - Updated rule content to align with Microsoft Azure Well-Architected Framework pillars. [#23](https://github.com/microsoft/PSRule.Rules.CAF/issues/23)
   - Updated naming rules to check for recommended naming prefixes. [#29](https://github.com/microsoft/PSRule.Rules.CAF/issues/29)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.1.0-B2008005:

- General improvements:
  - Updated rule content to align with Microsoft Azure Well-Architected Framework pillars. #23
  - Updated naming rules to check for recommended naming prefixes. #29
    - Checks to determine if a resource name is valid are available in `PSRule.Rules.Azure`.
- Engineering:
  - Updated to PSRule v0.20.0. #24
- Bug fixes:
  - Fixed Storage Account `st` prefix. #28
  - Fixed Virtual Network Gateway `vgw-` prefix. #30
  - Fixed Virtual Machine `vm` prefix. #31
  - Fixed Load Balancer `lbe-` and `lbi-` prefixes. #32
  - Fixed exclude `AzureFirewallSubnet` from `CAF.Name.Subnet`. #27

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
