### PR TITLE
Pre-release v0.1.0-B2012004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.1.0-B2012004 (pre-release)
+
+What's changed since pre-release v0.1.0-B2009009:
+
 - General improvements:
   - Resource name rules are case-sensitive by default. [#36](https://github.com/microsoft/PSRule.Rules.CAF/issues/36)
   - Resource and resource group tagging rules are case-sensitive by default. [#35](https://github.com/microsoft/PSRule.Rules.CAF/issues/35)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.1.0-B2009009:

- General improvements:
  - Resource name rules are case-sensitive by default. #36
  - Resource and resource group tagging rules are case-sensitive by default. #35
  - **Breaking change**: Separated resource and resource group tagging rules. #38
    - Renamed `CAF.Tag.Required` to `CAF.Tag.Resource`.
    - Moved resource group tagging requirements from `CAF.Tag.Resource` to `CAF.Tag.ResourceGroup`.
- Engineering:
  - Updated to PSRule v1.0.0. #37

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
