### PR TITLE
Fixed use of lower case Tags resource property #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.1.0-B2012004:
+
+- Bug fixes:
+  - Fixed use of lower case `Tags` resource property. [#43](https://github.com/microsoft/PSRule.Rules.CAF/issues/43)
+
 ## v0.1.0-B2012004 (pre-release)
 
 What's changed since pre-release v0.1.0-B2009009:

--- a/src/PSRule.Rules.CAF/rules/CAF.Tag.Rule.ps1
+++ b/src/PSRule.Rules.CAF/rules/CAF.Tag.Rule.ps1
@@ -11,7 +11,7 @@ Rule 'CAF.Tag.Resource' -If { (CAF_SupportsTags) -and !(CAF_IsResourceGroup) -an
     if ($required.Length -eq 0) {
         return $Assert.Pass();
     }
-    $Assert.HasField($TargetObject, 'Tags');
+    $Assert.HasField($TargetObject, 'tags');
     if ($Null -ne $TargetObject.Tags) {
         $Assert.HasFields($TargetObject.Tags, $required, $Configuration.CAF_MatchTagNameCase);
     }
@@ -23,14 +23,17 @@ Rule 'CAF.Tag.ResourceGroup' -Type 'Microsoft.Resources/resourceGroups' -If { ($
     if ($required.Length -eq 0) {
         return $Assert.Pass();
     }
-    $Assert.HasField($TargetObject, 'Tags');
+    $Assert.HasField($TargetObject, 'tags');
     if ($Null -ne $TargetObject.Tags) {
         $Assert.HasFields($TargetObject.Tags, $required, $Configuration.CAF_MatchTagNameCase);
     }
 }
 
 # Synopsis: Tag resources and resource groups with a valid environment.
-Rule 'CAF.Tag.Environment' -If { (CAF_SupportsTags) -and (Exists "Tags.$($Configuration.CAF_EnvironmentTag)") } {
-    $Assert.HasField($TargetObject, "Tags.$($Configuration.CAF_EnvironmentTag)", $Configuration.CAF_MatchTagNameCase);
-    $Assert.In($TargetObject, "Tags.$($Configuration.CAF_EnvironmentTag)", $Configuration.CAF_Environments, $Configuration.CAF_MatchTagValueCase)
+Rule 'CAF.Tag.Environment' -If { (CAF_SupportsTags) -and (Exists "tags.$($Configuration.CAF_EnvironmentTag)") } {
+    $Assert.HasField($TargetObject, 'tags');
+    if ($Null -ne $TargetObject.Tags) {
+        $Assert.HasField($TargetObject.Tags, $Configuration.CAF_EnvironmentTag, $Configuration.CAF_MatchTagNameCase);
+        $Assert.In($TargetObject.Tags, $Configuration.CAF_EnvironmentTag, $Configuration.CAF_Environments, $Configuration.CAF_MatchTagValueCase);
+    }
 }

--- a/tests/PSRule.Rules.CAF.Tests/CAF.Tag.Tests.ps1
+++ b/tests/PSRule.Rules.CAF.Tests/CAF.Tag.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'CAF.Tag' -Tag 'tag' {
             @{
                 Name = 'vnet-A'
                 Type = 'Microsoft.Network/virtualNetworks'
-                Tags = @{
+                tags = @{
                     Env = 'Prod'
                 }
             },


### PR DESCRIPTION
## PR Summary

- Fixed use of lower case `Tags` resource property. #43

Fixes #43 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.CAF/blob/main/CHANGELOG.md) has been updated with change under unreleased section
