### PR TITLE
Bump PSRule dependency to v1.0.1 #49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.1.0-B2101004:
+
+- Engineering:
+  - Bump PSRule dependency to v1.0.1. [#49](https://github.com/microsoft/PSRule.Rules.CAF/issues/49)
+  - Bump PSRule.Rules.Azure dependency to v0.19.0. [#49](https://github.com/microsoft/PSRule.Rules.CAF/issues/49)
+
 ## v0.1.0-B2101004 (pre-release)
 
 What's changed since pre-release v0.1.0-B2012004:
@@ -20,7 +26,7 @@ What's changed since pre-release v0.1.0-B2009009:
     - Renamed `CAF.Tag.Required` to `CAF.Tag.Resource`.
     - Moved resource group tagging requirements from `CAF.Tag.Resource` to `CAF.Tag.ResourceGroup`.
 - Engineering:
-  - Updated to PSRule v1.0.0. [#37](https://github.com/microsoft/PSRule.Rules.CAF/issues/37)
+  - Bump PSRule dependency to v1.0.0. [#37](https://github.com/microsoft/PSRule.Rules.CAF/issues/37)
 
 ## v0.1.0-B2009009 (pre-release)
 
@@ -31,7 +37,7 @@ What's changed since pre-release v0.1.0-B2008005:
   - Updated naming rules to check for recommended naming prefixes. [#29](https://github.com/microsoft/PSRule.Rules.CAF/issues/29)
     - Checks to determine if a resource name is valid are available in `PSRule.Rules.Azure`.
 - Engineering:
-  - Updated to PSRule v0.20.0. [#24](https://github.com/microsoft/PSRule.Rules.CAF/issues/24)
+  - Bump PSRule dependency to v0.20.0. [#24](https://github.com/microsoft/PSRule.Rules.CAF/issues/24)
 - Bug fixes:
   - Fixed Storage Account `st` prefix. [#28](https://github.com/microsoft/PSRule.Rules.CAF/issues/28)
   - Fixed Virtual Network Gateway `vgw-` prefix. [#30](https://github.com/microsoft/PSRule.Rules.CAF/issues/30)

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -108,10 +108,10 @@ task VersionModule ModuleDependencies, {
     $manifest = Test-ModuleManifest -Path $manifestPath;
     $requiredModules = $manifest.RequiredModules | ForEach-Object -Process {
         if ($_.Name -eq 'PSRule' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule'; ModuleVersion = '1.0.0' }
+            @{ ModuleName = 'PSRule'; ModuleVersion = '1.0.1' }
         }
         elseif ($_.Name -eq 'PSRule.Rules.Azure' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule.Rules.Azure'; ModuleVersion = '0.18.0' }
+            @{ ModuleName = 'PSRule.Rules.Azure'; ModuleVersion = '0.19.0' }
         }
         else {
             @{ ModuleName = $_.Name; ModuleVersion = $_.Version }
@@ -161,11 +161,11 @@ task PSScriptAnalyzer NuGet, {
 
 # Synopsis: Install PSRule
 task PSRule NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion '1.0.0' -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion '1.0.0' -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.0.1 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.0.1 -Scope CurrentUser -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.Azure -MinimumVersion '0.18.0' -ErrorAction Ignore)) {
-        Install-Module -Name PSRule.Rules.Azure -Repository PSGallery -MinimumVersion '0.18.0' -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.Azure -MinimumVersion 0.19.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule.Rules.Azure -Repository PSGallery -MinimumVersion 0.19.0 -Scope CurrentUser -Force;
     }
     Import-Module -Name PSRule.Rules.Azure -Verbose:$False;
 }

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -16,8 +16,8 @@ bugs:
   url: https://github.com/Microsoft/PSRule.Rules.CAF/issues
 
 modules:
-  PSRule: ^1.0.0
-  PSRule.Rules.Azure: ^0.18.0
+  PSRule: ^1.0.1
+  PSRule.Rules.Azure: ^0.19.0
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

- Engineering:
  - Bump PSRule dependency to v1.0.1. #49
  - Bump PSRule.Rules.Azure dependency to v0.19.0. #49

Fixes #49 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
