### PR TITLE
Added naming rules #63 #64 #65

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -2,12 +2,12 @@
 # CI pipeline for PSRule.Rules.CAF
 
 variables:
-  version: '0.1.0'
+  version: '0.2.0'
   buildConfiguration: 'Release'
   disable.coverage.autogenerate: 'true'
   imageName: 'ubuntu-18.04'
 
- # Use build number format, i.e. 0.1.0-B2004001
+ # Use build number format, i.e. 0.2.0-B2104001
 name: $(version)-B$(date:yyMM)$(rev:rrr)
 
 trigger:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 What's changed since v0.1.0:
 
+- New rules:
+  - Resource naming:
+    - Check that Cognitive Search services use a standard name prefix `srch-`. [#64](https://github.com/microsoft/PSRule.Rules.CAF/issues/64)
+    - Check that Cognitive Services accounts use a standard name prefix `cog-`. [#65](https://github.com/microsoft/PSRule.Rules.CAF/issues/65)
+    - Check that EventGrid Domains use a standard name prefix `evgd-`. [#63](https://github.com/microsoft/PSRule.Rules.CAF/issues/63)
+    - Check that EventGrid Topics use a standard name prefix `evgt-`. [#63](https://github.com/microsoft/PSRule.Rules.CAF/issues/63)
+    - Check that EventGrid System Topics use a standard name prefix `evgt-`. [#63](https://github.com/microsoft/PSRule.Rules.CAF/issues/63)
 - Engineering:
   - Bump PSRule dependency to v1.2.0. [#61](https://github.com/microsoft/PSRule.Rules.CAF/issues/61)
   - Bump PSRule.Rules.Azure dependency to v1.2.0. [#61](https://github.com/microsoft/PSRule.Rules.CAF/issues/61)

--- a/docs/rules/en/CAF.Name.CognitiveSearch.md
+++ b/docs/rules/en/CAF.Name.CognitiveSearch.md
@@ -1,0 +1,49 @@
+---
+pillar: Operational Excellence
+category: Resource naming
+online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.CognitiveSearch.md
+---
+
+# Use standard cognitive search names
+
+## SYNOPSIS
+
+Cognitive Search names should use a standard prefix.
+
+## DESCRIPTION
+
+An effective naming convention allows operators to quickly identify resource type, associated workload,
+deployment environment and Azure region.
+
+For cognitive search, the Cloud Adoption Framework recommends using the `srch-` prefix.
+
+Requirements for cognitive search names:
+
+- At least 2 character, but no more than 60.
+- Can include lowercase alphanumeric, and hyphen characters.
+- The first two and last character of the name must be a letter or number.
+- Cannot contain consecutive hyphens.
+- Cognitive Search accounts must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider creating cognitive search instances with a standard name.
+Additionally consider using Azure Policy to only permit creation using a standard naming convention.
+
+## NOTES
+
+This rule does not check if cognitive search names are unique.
+
+To configure this rule:
+
+- Override the `CAF_SearchPrefix` configuration value with an array of allowed prefixes.
+- Override `CAF_UseLowerNames` with `false` to allow mixed case in resource names.
+By default only lower-case letters and other supported characters are allowed.
+This option affects all resource name rules.
+
+## LINKS
+
+- [Recommended abbreviations for Azure resource types](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/devops/app-design#tagging-and-resource-naming)
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.search/searchservices)

--- a/docs/rules/en/CAF.Name.CognitiveServices.md
+++ b/docs/rules/en/CAF.Name.CognitiveServices.md
@@ -1,0 +1,48 @@
+---
+pillar: Operational Excellence
+category: Resource naming
+online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.CognitiveServices.md
+---
+
+# Use standard cognitive services accounts names
+
+## SYNOPSIS
+
+Cognitive Services account names should use a standard prefix.
+
+## DESCRIPTION
+
+An effective naming convention allows operators to quickly identify resource type, associated workload,
+deployment environment and Azure region.
+
+For cognitive services accounts, the Cloud Adoption Framework recommends using the `cog-` prefix.
+
+Requirements for cognitive services account names:
+
+- At least 2 character, but no more than 64.
+- Can include alphanumeric, and hyphen characters.
+- Can only start and end with a letter or number.
+- Cognitive Services accounts must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider creating cognitive services accounts with a standard name.
+Additionally consider using Azure Policy to only permit creation using a standard naming convention.
+
+## NOTES
+
+This rule does not check if cognitive services names are unique.
+
+To configure this rule:
+
+- Override the `CAF_CognitiveServicesPrefix` configuration value with an array of allowed prefixes.
+- Override `CAF_UseLowerNames` with `false` to allow mixed case in resource names.
+By default only lower-case letters and other supported characters are allowed.
+This option affects all resource name rules.
+
+## LINKS
+
+- [Recommended abbreviations for Azure resource types](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/devops/app-design#tagging-and-resource-naming)
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.cognitiveservices/accounts)

--- a/docs/rules/en/CAF.Name.EventGridDomain.md
+++ b/docs/rules/en/CAF.Name.EventGridDomain.md
@@ -1,0 +1,47 @@
+---
+pillar: Operational Excellence
+category: Resource naming
+online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.EventGridDomain.md
+---
+
+# Use standard EventGrid domain names
+
+## SYNOPSIS
+
+EventGrid domain names should use a standard prefix.
+
+## DESCRIPTION
+
+An effective naming convention allows operators to quickly identify resource type, associated workload,
+deployment environment and Azure region.
+
+For EventGrid domains, the Cloud Adoption Framework recommends using the `evgd-` prefix.
+
+Requirements for EventGrid domain names:
+
+- At least 3 character, but no more than 50.
+- Can include alphanumeric, and hyphen characters.
+- EventGrid domains must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider creating EventGrid domains with a standard name.
+Additionally consider using Azure Policy to only permit creation using a standard naming convention.
+
+## NOTES
+
+This rule does not check if EventGrid domain names are unique.
+
+To configure this rule:
+
+- Override the `CAF_EventGridDomain` configuration value with an array of allowed prefixes.
+- Override `CAF_UseLowerNames` with `false` to allow mixed case in resource names.
+By default only lower-case letters and other supported characters are allowed.
+This option affects all resource name rules.
+
+## LINKS
+
+- [Recommended abbreviations for Azure resource types](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/devops/app-design#tagging-and-resource-naming)
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.eventgrid/domains)

--- a/docs/rules/en/CAF.Name.EventGridSystemTopic.md
+++ b/docs/rules/en/CAF.Name.EventGridSystemTopic.md
@@ -1,0 +1,47 @@
+---
+pillar: Operational Excellence
+category: Resource naming
+online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.EventGridSystemTopic.md
+---
+
+# Use standard EventGrid system topic names
+
+## SYNOPSIS
+
+EventGrid system topic names should use a standard prefix.
+
+## DESCRIPTION
+
+An effective naming convention allows operators to quickly identify resource type, associated workload,
+deployment environment and Azure region.
+
+For EventGrid system topics, the Cloud Adoption Framework recommends using the `evgt-` prefix.
+
+Requirements for EventGrid system topic names:
+
+- At least 3 character, but no more than 50.
+- Can include alphanumeric, and hyphen characters.
+- EventGrid system topics must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider creating EventGrid system topics with a standard name.
+Additionally consider using Azure Policy to only permit creation using a standard naming convention.
+
+## NOTES
+
+This rule does not check if EventGrid system topic names are unique.
+
+To configure this rule:
+
+- Override the `CAF_EventGridSystemTopic` configuration value with an array of allowed prefixes.
+- Override `CAF_UseLowerNames` with `false` to allow mixed case in resource names.
+By default only lower-case letters and other supported characters are allowed.
+This option affects all resource name rules.
+
+## LINKS
+
+- [Recommended abbreviations for Azure resource types](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/devops/app-design#tagging-and-resource-naming)
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.eventgrid/systemtopics)

--- a/docs/rules/en/CAF.Name.EventGridTopic.md
+++ b/docs/rules/en/CAF.Name.EventGridTopic.md
@@ -1,0 +1,47 @@
+---
+pillar: Operational Excellence
+category: Resource naming
+online version: https://github.com/microsoft/PSRule.Rules.CAF/blob/main/docs/rules/en/CAF.Name.EventGridTopic.md
+---
+
+# Use standard EventGrid topic names
+
+## SYNOPSIS
+
+EventGrid topic names should use a standard prefix.
+
+## DESCRIPTION
+
+An effective naming convention allows operators to quickly identify resource type, associated workload,
+deployment environment and Azure region.
+
+For EventGrid topics, the Cloud Adoption Framework recommends using the `evgt-` prefix.
+
+Requirements for EventGrid topic names:
+
+- At least 3 character, but no more than 50.
+- Can include alphanumeric, and hyphen characters.
+- EventGrid topics must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider creating EventGrid topics with a standard name.
+Additionally consider using Azure Policy to only permit creation using a standard naming convention.
+
+## NOTES
+
+This rule does not check if EventGrid topics names are unique.
+
+To configure this rule:
+
+- Override the `CAF_EventGridTopic` configuration value with an array of allowed prefixes.
+- Override `CAF_UseLowerNames` with `false` to allow mixed case in resource names.
+By default only lower-case letters and other supported characters are allowed.
+This option affects all resource name rules.
+
+## LINKS
+
+- [Recommended abbreviations for Azure resource types](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure Well-Architected Framework](https://docs.microsoft.com/azure/architecture/framework/devops/app-design#tagging-and-resource-naming)
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.eventgrid/topics)

--- a/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
@@ -93,6 +93,9 @@ spec:
     CAF_HDInsightsSparkPrefix: [ 'spark-' ]
     CAF_IoTHubPrefix: [ 'iot-' ]
     CAF_PowerBIEmbeddedPrefix: [ 'pbi-' ]
+    CAF_EventGridDomain: [ 'evgd-' ]
+    CAF_EventGridTopic: [ 'evgt-' ]
+    CAF_EventGridSystemTopic: [ 'evgt-' ]
 
     # Integration
     CAF_LogicAppsPrefix: [ 'logic-' ]

--- a/src/PSRule.Rules.CAF/rules/CAF.Name.Rule.ps1
+++ b/src/PSRule.Rules.CAF/rules/CAF.Name.Rule.ps1
@@ -3,8 +3,8 @@
 
 # Note:
 # This contains rules for standard naming suggested in the CAF.
-# https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
-# https://docs.microsoft.com/en-us/azure/architecture/best-practices/resource-naming
+# https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
+# https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
 
 # Synopsis: Use standard resource groups names.
 Rule 'CAF.Name.RG' -Type 'Microsoft.Resources/resourceGroups' -If { !(CAF_IsManagedRG) } {
@@ -101,6 +101,47 @@ Rule 'CAF.Name.PublicIP' -Type 'Microsoft.Network/publicIPAddresses' {
 # Synopsis: Use standard load balancer names.
 Rule 'CAF.Name.LoadBalancer' -Type 'Microsoft.Network/loadBalancers' -If { !(CAF_IsManagedLB) } {
     $Assert.StartsWith($PSRule, 'TargetName', $Configuration.CAF_LoadBalancerPrefix, $True);
+    if ($Configuration.CAF_UseLowerNames -eq $True) {
+        $Assert.IsLower($PSRule, 'TargetName');
+    }
+}
+
+# Synopsis: Use standard cognitive search names.
+Rule 'CAF.Name.CognitiveSearch' -Type 'Microsoft.Search/searchServices' {
+    $Assert.StartsWith($PSRule, 'TargetName', $Configuration.CAF_SearchPrefix, $True);
+    if ($Configuration.CAF_UseLowerNames -eq $True) {
+        $Assert.IsLower($PSRule, 'TargetName');
+    }
+}
+
+# Synopsis: Use standard cognitive services names.
+Rule 'CAF.Name.CognitiveServices' -Type 'Microsoft.CognitiveServices/accounts' {
+    $Assert.StartsWith($PSRule, 'TargetName', $Configuration.CAF_CognitiveServicesPrefix, $True);
+    if ($Configuration.CAF_UseLowerNames -eq $True) {
+        $Assert.IsLower($PSRule, 'TargetName');
+    }
+}
+
+# Synopsis: Use standard Event Grid Domain names.
+Rule 'CAF.Name.EventGridDomain' -Type 'Microsoft.EventGrid/domains' {
+    $Assert.StartsWith($PSRule, 'TargetName', $Configuration.CAF_EventGridDomain, $True);
+    if ($Configuration.CAF_UseLowerNames -eq $True) {
+        $Assert.IsLower($PSRule, 'TargetName');
+    }
+}
+
+# Synopsis: Use standard Event Grid Topic names.
+Rule 'CAF.Name.EventGridTopic' -Type 'Microsoft.EventGrid/topics', 'Microsoft.EventGrid/domains/topics' {
+    $name = $PSRule.TargetName.Split('/')[-1];
+    $Assert.StartsWith($name, '.', $Configuration.CAF_EventGridTopic, $True);
+    if ($Configuration.CAF_UseLowerNames -eq $True) {
+        $Assert.IsLower($name, '.');
+    }
+}
+
+# Synopsis: Use standard Event Grid System Topic names.
+Rule 'CAF.Name.EventGridSystemTopic' -Type 'Microsoft.EventGrid/systemTopics' {
+    $Assert.StartsWith($PSRule, 'TargetName', $Configuration.CAF_EventGridSystemTopic, $True);
     if ($Configuration.CAF_UseLowerNames -eq $True) {
         $Assert.IsLower($PSRule, 'TargetName');
     }

--- a/tests/PSRule.Rules.CAF.Tests/CAF.Name.Tests.ps1
+++ b/tests/PSRule.Rules.CAF.Tests/CAF.Name.Tests.ps1
@@ -442,4 +442,179 @@ Describe 'CAF.Name' -Tag 'name' {
             }
         }
     }
+
+    Context 'CAF.Name.CognitiveSearch' {
+        $validNames = @(
+            'srch-test-001'
+        )
+        $invalidNames = @(
+            'srch-Test-001'
+            'srchtest001'
+            'test-srch-001'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.Search/searchServices'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.CognitiveSearch';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.CognitiveSearch';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'CAF.Name.CognitiveServices' {
+        $validNames = @(
+            'cog-test-001'
+        )
+        $invalidNames = @(
+            'cog-Test-001'
+            'cogtest001'
+            'test-cog-001'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.CognitiveServices/accounts'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.CognitiveServices';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.CognitiveServices';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'CAF.Name.EventGridDomain' {
+        $validNames = @(
+            'evgd-test-001'
+        )
+        $invalidNames = @(
+            'evgd-Test-001'
+            'evgdtest001'
+            'test-evgd-001'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.EventGrid/domains'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.EventGridDomain';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.EventGridDomain';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'CAF.Name.EventGridTopic' {
+        $validNames = @(
+            'evgt-test-001'
+        )
+        $invalidNames = @(
+            'evgt-Test-001'
+            'evgttest001'
+            'test-evgt-001'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.EventGrid/topics'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.EventGridTopic';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.EventGridTopic';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'CAF.Name.EventGridSystemTopic' {
+        $validNames = @(
+            'evgt-test-001'
+        )
+        $invalidNames = @(
+            'evgt-Test-001'
+            'evgttest001'
+            'test-evgt-001'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.EventGrid/systemTopics'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.EventGridSystemTopic';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'CAF.Name.EventGridSystemTopic';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

- Check that Cognitive Search services use a standard name prefix `srch-`.
- Check that Cognitive Services accounts use a standard name prefix `cog-`.
- Check that EventGrid Domains use a standard name prefix `evgd-`.
- Check that EventGrid Topics use a standard name prefix `evgt-`.
- Check that EventGrid System Topics use a standard name prefix `evgt-`.

Fixes #63 
Fixes #64 
Fixes #65 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.CAF/blob/main/CHANGELOG.md) has been updated with change under unreleased section
