### PR TITLE
Bump PSRule versions #77 #78 #79

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -124,7 +124,7 @@ stages:
   - template: jobs/test.yaml
     parameters:
       name: windows_2019
-      displayName: 'PowerShell 7.1 - Windows 2019'
+      displayName: 'PowerShell 5.1 - Windows 2019'
       imageName: 'windows-2019'
       pwsh: 'false'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+What's changed since v0.2.0:
+
+- General improvements:
+  - Updated default baseline to use module configuration. [#79](https://github.com/microsoft/PSRule.Rules.CAF/issues/79)
+- Engineering:
+  - Bump PSRule dependency to v1.9.0. [#77](https://github.com/microsoft/PSRule.Rules.CAF/issues/77)
+  - Bump PSRule.Rules.Azure dependency to v1.9.1. [#78](https://github.com/microsoft/PSRule.Rules.CAF/issues/78)
+
 ## v0.2.0
 
 What's changed since v0.1.0:

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -108,19 +108,16 @@ task VersionModule ModuleDependencies, {
     $manifest = Test-ModuleManifest -Path $manifestPath;
     $requiredModules = $manifest.RequiredModules | ForEach-Object -Process {
         if ($_.Name -eq 'PSRule' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule'; ModuleVersion = '1.3.0' }
+            @{ ModuleName = 'PSRule'; ModuleVersion = '1.9.0' }
         }
         elseif ($_.Name -eq 'PSRule.Rules.Azure' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule.Rules.Azure'; ModuleVersion = '1.3.2' }
+            @{ ModuleName = 'PSRule.Rules.Azure'; ModuleVersion = '1.9.1' }
         }
         else {
             @{ ModuleName = $_.Name; ModuleVersion = $_.Version }
         }
     };
     Update-ModuleManifest -Path $manifestPath -RequiredModules $requiredModules;
-    $manifestContent = Get-Content -Path $manifestPath -Raw;
-    $manifestContent = $manifestContent -replace 'PSRule = ''System.Collections.Hashtable''', 'PSRule = @{ Baseline = ''CAF.Strict'' }';
-    $manifestContent | Set-Content -Path $manifestPath;
 }
 
 # Synopsis: Publish to PowerShell Gallery
@@ -161,11 +158,11 @@ task PSScriptAnalyzer NuGet, {
 
 # Synopsis: Install PSRule
 task PSRule NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.3.0 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.3.0 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.9.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.9.0 -Scope CurrentUser -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.Azure -MinimumVersion 1.3.2 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule.Rules.Azure -Repository PSGallery -MinimumVersion 1.3.2 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.Azure -MinimumVersion 1.9.1 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule.Rules.Azure -Repository PSGallery -MinimumVersion 1.9.1 -Scope CurrentUser -Force;
     }
     if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.MSFT.OSS -MinimumVersion 0.1.0 -ErrorAction Ignore)) {
         Install-Module -Name PSRule.Rules.MSFT.OSS -Repository PSGallery -MinimumVersion 0.1.0 -Scope CurrentUser -Force;

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -16,8 +16,8 @@ bugs:
   url: https://github.com/Microsoft/PSRule.Rules.CAF/issues
 
 modules:
-  PSRule: ^1.3.0
-  PSRule.Rules.Azure: ^1.3.2
+  PSRule: ^1.9.0
+  PSRule.Rules.Azure: ^1.9.1
 
 tasks:
   clear:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -5,6 +5,9 @@
 # Please see the documentation for all configuration options:
 # https://microsoft.github.io/PSRule/
 
+requires:
+  PSRule: '@pre >=1.9.0'
+
 input:
   pathIgnore:
   - '.vscode/'
@@ -22,3 +25,8 @@ include:
 output:
   culture:
   - en-US
+
+configuration:
+  # Authoring rules
+  # RULE_AUTHORING_ONLINE_HELP: 'https://azure.github.io/PSRule.Rules.CAF/en/rules/'
+  RULE_AUTHORING_PREFIX: 'CAF'

--- a/src/PSRule.Rules.CAF/PSRule.Rules.CAF.psd1
+++ b/src/PSRule.Rules.CAF/PSRule.Rules.CAF.psd1
@@ -110,9 +110,6 @@ PrivateData = @{
         # ReleaseNotes of this module
         ReleaseNotes = 'https://github.com/Microsoft/PSRule.Rules.CAF/blob/main/CHANGELOG.md'
     } # End of PSData hashtable
-    PSRule = @{
-        Baseline = 'CAF.Strict'
-    }
 } # End of PrivateData hashtable
 
 # HelpInfo URI of this module

--- a/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 ---
 # Synopsis: The default baseline for Azure Cloud Adoption Framework

--- a/src/PSRule.Rules.CAF/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Config.Rule.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 ---
 # Synopsis: Configuration for PSRule.Rules.CAF
@@ -17,3 +19,5 @@ spec:
       resourceId: [ 'ResourceId' ]
       subscriptionId: [ 'SubscriptionId' ]
       resourceGroupName: [ 'ResourceGroupName' ]
+  rule:
+    baseline: 'CAF.Strict'


### PR DESCRIPTION
## PR Summary

What's changed since v0.2.0:

- General improvements:
  - Updated default baseline to use module configuration. #79
- Engineering:
  - Bump PSRule dependency to v1.9.0. #77
  - Bump PSRule.Rules.Azure dependency to v1.9.1. #78

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

