### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 **Module in use and version:**
 
 - Module: PSRule.Rules.CAF
-- Version: **[e.g. 0.1.0]**
+- Version: **[e.g. 0.3.0]**
 
 Captured output from `$PSVersionTable`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## v0.3.0
+
+What's changed since v0.2.0:
+
+- General improvements:
+  - Updated default baseline to use module configuration. [#79](https://github.com/microsoft/PSRule.Rules.CAF/issues/79)
+- Engineering:
+  - Bump PSRule dependency to v1.9.0. [#77](https://github.com/microsoft/PSRule.Rules.CAF/issues/77)
+  - Bump PSRule.Rules.Azure dependency to v1.9.1. [#78](https://github.com/microsoft/PSRule.Rules.CAF/issues/78)
+
+What's changed since pre-release v0.3.0-B2111006:
+
+- No additional changes.
+
 ## v0.3.0-B2111006 (pre-release)
 
 What's changed since v0.2.0:


### PR DESCRIPTION
## PR Summary

What's changed since v0.2.0:

- General improvements:
  - Updated default baseline to use module configuration. #79
- Engineering:
  - Bump PSRule dependency to v1.9.0. #77
  - Bump PSRule.Rules.Azure dependency to v1.9.1. #78

What's changed since pre-release v0.3.0-B2111006:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
