### PR TITLE
Pre-release v0.4.0-B2204008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+## v0.4.0-B2204008 (pre-release)
+
 What's changed since v0.3.0:
 
 - Engineering:
   - Bump PSRule dependency to v2.0.0. [#90](https://github.com/microsoft/PSRule.Rules.CAF/pull/90)
-  - Bump PSRule.Rules.Azure dependency to v1.13.2. [#94](https://github.com/microsoft/PSRule.Rules.CAF/pull/94)
+  - Bump PSRule.Rules.Azure dependency to v1.14.1. [#94](https://github.com/microsoft/PSRule.Rules.CAF/pull/94)
 
 ## v0.3.0
 


### PR DESCRIPTION
## PR Summary

What's changed since v0.3.0:

- Engineering:
  - Bump PSRule dependency to v2.0.0. #90
  - Bump PSRule.Rules.Azure dependency to v1.14.1. #94

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
