### PR TITLE
Pre-release v0.4.0-B2205006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0-B2205006 (pre-release)
+
 What's changed since pre-release v0.4.0-B2204019:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.4.0-B2204019:

- Engineering:
  - Bump PSRule to v2.1.0. #107
  - Bump PSRule.Rules.Azure to v1.15.0. #107
  - Bump Pester to 5.3.3. #106

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
