### PR TITLE
Pre-release v0.4.0-B2208003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0-B2208003 (pre-release)
+
 What's changed since pre-release v0.4.0-B2205006:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.4.0-B2205006:

- Engineering:
  - Bump PSRule to v2.2.0.
    [#113](https://github.com/microsoft/PSRule.Rules.CAF/pull/113)
  - Bump PSRule.Rules.Azure to v1.17.1.
    [#113](https://github.com/microsoft/PSRule.Rules.CAF/pull/113)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
