### PR TITLE
Pre-release v0.4.0-B2302008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0-B2302008 (pre-release)
+
 What's changed since pre-release v0.4.0-B2208003:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.4.0-B2208003:

- Engineering:
  - Bump PSRule to v2.7.0.
    [#127](https://github.com/microsoft/PSRule.Rules.CAF/pull/127)
  - Bump PSRule.Rules.Azure to v1.24.2.
    [#127](https://github.com/microsoft/PSRule.Rules.CAF/pull/127)
  - Bump Pester to v5.4.0.
    [#127](https://github.com/microsoft/PSRule.Rules.CAF/pull/127)
  - Bump PSScriptAnalyzer to v1.21.0.
    [#116](https://github.com/microsoft/PSRule.Rules.CAF/pull/116)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
