### PR TITLE
Update route table prefix from 'route-' to 'rt-' in documentation and rules

### DIFF
--- a/docs/baselines/en/CAF.Strict.md
+++ b/docs/baselines/en/CAF.Strict.md
@@ -45,7 +45,7 @@ CAF_LocalNetworkGatewayPrefix | `lgw-`
 CAF_VirtualNetworkGatewayPrefix | `vgw-`
 CAF_GatewayConnectionPrefix | `cn-`
 CAF_ApplicationGatewayPrefix | `agw-`
-CAF_RouteTablePrefix | `route-`
+CAF_RouteTablePrefix | `rt-`
 CAF_TrafficManagerProfilePrefix | `traf-`
 CAF_FrontDoorPrefix | `fd-`
 CAF_CDNProfilePrefix | `cdnp-`

--- a/docs/rules/en/CAF.Name.Route.md
+++ b/docs/rules/en/CAF.Name.Route.md
@@ -15,7 +15,7 @@ Route table names should use a standard prefix.
 An effective naming convention allows operators to quickly identify resource type, associated workload,
 deployment environment and Azure region.
 
-For route tables, the Cloud Adoption Framework recommends using the `route-` prefix.
+For route tables, the Cloud Adoption Framework recommends using the `rt-` prefix.
 
 Requirements for route table names:
 

--- a/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.CAF/rules/Baseline.Rule.yaml
@@ -46,7 +46,7 @@ spec:
     CAF_VirtualNetworkGatewayPrefix: [ 'vgw-' ]
     CAF_GatewayConnectionPrefix: [ 'cn-' ]
     CAF_ApplicationGatewayPrefix: [ 'agw-' ]
-    CAF_RouteTablePrefix: [ 'route-' ]
+    CAF_RouteTablePrefix: [ 'rt-' ]
     CAF_TrafficManagerProfilePrefix: [ 'traf-' ]
     CAF_FrontDoorPrefix: [ 'fd-' ]
     CAF_CDNProfilePrefix: [ 'cdnp-' ]

--- a/tests/PSRule.Rules.CAF.Tests/CAF.Name.Tests.ps1
+++ b/tests/PSRule.Rules.CAF.Tests/CAF.Name.Tests.ps1
@@ -265,11 +265,12 @@ Describe 'CAF.Name' -Tag 'name' {
     Context 'CAF.Name.Route' {
         BeforeDiscovery {
             $validNames = @(
-                'route-test-001'
+                'rt-test-001'
             )
             $invalidNames = @(
                 'route-Test-001'
                 'routetest001'
+                'route-test-001'
                 'test-route-001'
             )
         }


### PR DESCRIPTION
## PR Summary

Update route table prefix from 'route-' to 'rt-' in documentation and rules

As per https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Microsoft/PSRule.Rules.CAF/blob/main/CHANGELOG.md) has been updated with change under unreleased section
